### PR TITLE
scratchpad post->put + implement get method

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -10,7 +10,7 @@ app = Flask(__name__)
 api = Api(app)
 CORS(app)
 
-api.add_resource(Scratchpad, "/scratchpad")
+api.add_resource(Scratchpad, "/scratchpad/<string:id>")
 api.add_resource(GithubPodList, "/github/list-pods/<string:oAuth_token>")
 api.add_resource(
     GithubDiscussionList,

--- a/backend/widgets/scratchpad.py
+++ b/backend/widgets/scratchpad.py
@@ -1,15 +1,17 @@
 from flask_restful import Resource, reqparse
 
 scratchpad_parser = reqparse.RequestParser()
-scratchpad_parser.add_argument("text", required=True)
-scratchpad_parser.add_argument("id", required=True)
+scratchpad_parser.add_argument("text")
 
 
 class Scratchpad(Resource):
     db = {}  # temp
 
-    def post(self):
+    def put(self, id):
         args = scratchpad_parser.parse_args()
         self.db[args["id"]] = args["text"]
         print(self.db)
         return {args["id"]: self.db[args["id"]]}
+
+    def get(self, id):
+        return {id: self.db.get("id", "")}


### PR DESCRIPTION
Tiny PR but a couple of changes:
- scratchpad endpoint is now `/scratchpad/<string:id>`
- scratchpad now accepts `PUT` instead of `POST` to modify text for given ID
- scratchpad now accepts `GET` to retrieve text at an ID