### PR TITLE
Client can list relevant GitHub Issues 

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -5,6 +5,7 @@ from flask_cors import CORS
 from widgets.scratchpad import Scratchpad
 from widgets.github_discussions import GithubPodList, GithubDiscussionList
 from widgets.standup import GithubViewSubmitLatestStandup
+from widgets.github_issues import GithubIssueList
 
 app = Flask(__name__)
 api = Api(app)
@@ -19,6 +20,9 @@ api.add_resource(
 api.add_resource(
     GithubViewSubmitLatestStandup,
     "/github/standup/<string:pod_slug>/<string:oAuth_token>",
+)
+api.add_resource(
+    GithubIssueList, "/github/issues/<string:query_type>/<string:oAuth_token>"
 )
 
 if __name__ == "__main__":

--- a/backend/widgets/github_issues.py
+++ b/backend/widgets/github_issues.py
@@ -5,7 +5,7 @@ import requests
 
 class GithubIssueList(Resource):
     def get(self, oAuth_token, query_type):
-        if method not in ("assigned", "created", "mentioned", "subscribed"):
+        if query_type not in ("assigned", "created", "mentioned", "subscribed"):
             abort(
                 404,
                 "invalid query type! must be one of 'assigned', 'created', 'mentioned', or 'subscribed'.",
@@ -16,7 +16,7 @@ class GithubIssueList(Resource):
             "Authorization": f"token {oAuth_token}",
         }
         response = requests.get(
-            f"https://api.github.com/orgs/MLH-Fellowship/issues?filter={method}",
+            f"https://api.github.com/orgs/MLH-Fellowship/issues?filter={query_type}",
             headers=headers,
         )
         handle_github_request_errors(response)

--- a/backend/widgets/github_issues.py
+++ b/backend/widgets/github_issues.py
@@ -1,0 +1,34 @@
+from flask_restful import Resource, abort
+from utils.error_handling import handle_github_request_errors
+import requests
+
+
+class GithubIssueList(Resource):
+    def get(self, oAuth_token, query_type):
+        if method not in ("assigned", "created", "mentioned", "subscribed"):
+            abort(
+                404,
+                "invalid query type! must be one of 'assigned', 'created', 'mentioned', or 'subscribed'.",
+            )
+
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"token {oAuth_token}",
+        }
+        response = requests.get(
+            f"https://api.github.com/orgs/MLH-Fellowship/issues?filter={method}",
+            headers=headers,
+        )
+        handle_github_request_errors(response)
+        return [
+            {
+                "repo": issue["repository"]["name"],
+                "number": issue["number"],
+                "title": issue["title"],
+                "url": issue["url"],
+                "labels": [label["name"] for label in issue["labels"]],
+                "assignees": [assignee["login"] for assignee in issue["assignees"]],
+                "created_by": issue["user"]["login"],
+            }
+            for issue in response.json()
+        ]


### PR DESCRIPTION
Implements the endpoint
`GET /github/issues/<string:query_type>/<string:oAuth_token>` where `query_type` is one of `assigned`, `created`, `mentioned`, `subscribed`.

this endpoint lists info on Github Issues (**and Pull Requests**, which are technically considered Issues by Github's API) that are assigned to/created by/mention/subscribed to by the user within the MLH-Fellowship organisation!

sample request:
```
curl http://localhost:5000/github/issues/assigned/<oAuth_token>
```

sample response:
```
[
    {
        "repo": "fellow-dashboard",
        "number": 19,
        "title": "API endpoint - retrieve organisation issues/PRs assigned to user",
        "url": "https://api.github.com/repos/MLH-Fellowship/fellow-dashboard/issues/19",
        "labels": [
            "enhancement",
            "API"
        ],
        "assignees": [
            "kokrui"
        ],
        "created_by": "kokrui"
    },
    {
        "repo": "fellow-dashboard",
        "number": 18,
        "title": "API endpoint - retrieve github stats",
        "url": "https://api.github.com/repos/MLH-Fellowship/fellow-dashboard/issues/18",
        "labels": [
            "enhancement",
            "API"
        ],
        "assignees": [
            "kokrui",
            "EshikaShah"
        ],
        "created_by": "kokrui"
    }
]
```